### PR TITLE
Fix pickling of tracked instances when wrapped rather than decorated

### DIFF
--- a/src/confingy/tracking.py
+++ b/src/confingy/tracking.py
@@ -934,13 +934,50 @@ def _add_tracking_to_class(cls: type[Any], _validate: bool = True) -> type[Any]:
         init_kwargs = _args_to_kwargs(cls_arg, args, kwargs)
         return Lazy(cls_arg, init_kwargs)
 
+    def __reduce__(self: Any) -> tuple:
+        """Enable pickling of tracked instances.
+
+        The dynamically-created tracked subclass can't be found by pickle via
+        module path, so we reconstruct by re-importing the original class and
+        calling track(cls)(**init_args). Extra instance state (set after
+        __init__) is captured via __getstate__ and restored via __setstate__.
+        """
+        tracked_info = self._tracked_info
+        return (
+            _reconstruct_tracked_instance,
+            (tracked_info["module"], tracked_info["class"], tracked_info["init_args"]),
+            self.__dict__,
+        )
+
+    def __setstate__(self: Any, state: dict) -> None:
+        """Restore extra instance state after reconstruction."""
+        self.__dict__.update(state)
+
     new_cls.__init__ = init_with_tracking  # type: ignore
+    new_cls.__reduce__ = __reduce__
+    # Only add __setstate__ if the original class doesn't define one,
+    # to respect any custom unpickling logic.
+    if "__setstate__" not in cls.__dict__:
+        new_cls.__setstate__ = __setstate__
 
     # Always add lazy classmethod to each tracked class (even if inherited)
     # so that each class has the correct signature matching its __init__
     new_cls.lazy = classmethod(lazy_classmethod)  # type: ignore
 
     return new_cls
+
+
+def _reconstruct_tracked_instance(module: str, class_name: str, init_args: dict) -> Any:
+    """Reconstruct a tracked instance for unpickling.
+
+    Imports the original class from its module, wraps it with track(),
+    and calls it with the stored init_args.
+    """
+    import importlib
+
+    mod = importlib.import_module(module)
+    cls = getattr(mod, class_name)
+    return track(cls)(**init_args)
 
 
 def _create_tracked_instance(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,3 +151,28 @@ class Middle:
 class Outer:
     def __init__(self, middle: Lazy[Middle]):
         self.middle = middle
+
+
+class Untracked:
+    """A plain (untracked) class for testing inline track() pickling."""
+
+    def __init__(self, value: int):
+        self.value = value
+
+
+class UntrackedWithReduce:
+    """A class with a custom __reduce__ for testing tracked pickle doesn't clobber it."""
+
+    def __init__(self, value: int):
+        self.value = value
+        self.extra = "set_by_init"
+
+    def __reduce__(self):
+        return (_rebuild_untracked_with_reduce, (self.value, self.extra))
+
+
+def _rebuild_untracked_with_reduce(value: int, extra: str) -> "UntrackedWithReduce":
+    obj = UntrackedWithReduce.__new__(UntrackedWithReduce)
+    obj.value = value
+    obj.extra = extra
+    return obj

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -2771,6 +2771,67 @@ class TestPickleSupport:
         restored.value = 100
         assert restored.value == 100
 
+    def test_tracked_instance_can_be_pickled(self):
+        """Tracked instances (not just Lazy) should survive pickle round-trip."""
+        import pickle
+
+        from tests.conftest import Inner
+
+        instance = Inner(value=42)
+        assert hasattr(instance, "_tracked_info")
+
+        # Pickle and unpickle
+        pickled = pickle.dumps(instance)
+        restored = pickle.loads(pickled)
+
+        assert restored.value == 42
+        assert hasattr(restored, "_tracked_info")
+        assert restored._tracked_info["init_args"]["value"] == 42
+
+    def test_tracked_instance_inline_track_can_be_pickled(self):
+        """track(SomeClass)(args) instances should survive pickle round-trip.
+
+        This is the key regression: track() creates a dynamic subclass that
+        pickle can't find by module path, so we need __reduce__ support.
+        """
+        import pickle
+
+        from tests.conftest import Inner
+
+        # Inner is already @track-decorated, get the original untracked class
+        OrigInner = Inner.__bases__[0]
+
+        # Use track() inline (creates a new dynamic subclass)
+        instance = track(OrigInner)(value=99)
+        assert hasattr(instance, "_tracked_info")
+
+        # Pickle and unpickle
+        pickled = pickle.dumps(instance)
+        restored = pickle.loads(pickled)
+
+        assert restored.value == 99
+        assert hasattr(restored, "_tracked_info")
+        assert restored._tracked_info["init_args"]["value"] == 99
+
+    def test_tracked_instance_with_custom_reduce_can_be_pickled(self):
+        """track() on a class with its own __reduce__ should still be pickleable."""
+        import pickle
+
+        from tests.conftest import UntrackedWithReduce
+
+        instance = track(UntrackedWithReduce)(value=7)
+        assert hasattr(instance, "_tracked_info")
+        instance.extra = "modified_after_init"
+
+        # Pickle and unpickle
+        pickled = pickle.dumps(instance)
+        restored = pickle.loads(pickled)
+
+        assert restored.value == 7
+        assert hasattr(restored, "_tracked_info")
+        # Extra state set after init should be preserved
+        assert restored.extra == "modified_after_init"
+
     def test_pickle_preserves_was_instantiated_flag(self):
         """Lazy created via lens() should preserve _was_instantiated after unpickling."""
         import pickle


### PR DESCRIPTION
The dynamically-created subclass from track() has the same __name__/__module__ as the original class, so pickle can't resolve it. Add __reduce__/__setstate__ to reconstruct via re-importing the original class and re-tracking it.