### PR TITLE
Avoid re-running __init__ when unpickling tracked instances

### DIFF
--- a/src/confingy/tracking.py
+++ b/src/confingy/tracking.py
@@ -938,14 +938,13 @@ def _add_tracking_to_class(cls: type[Any], _validate: bool = True) -> type[Any]:
         """Enable pickling of tracked instances.
 
         The dynamically-created tracked subclass can't be found by pickle via
-        module path, so we reconstruct by re-importing the original class and
-        calling track(cls)(**init_args). Extra instance state (set after
-        __init__) is captured via __getstate__ and restored via __setstate__.
+        module path. We reconstruct by creating an empty tracked subclass via
+        __new__ (skipping __init__) and restoring __dict__ via __setstate__.
         """
         tracked_info = self._tracked_info
         return (
             _reconstruct_tracked_instance,
-            (tracked_info["module"], tracked_info["class"], tracked_info["init_args"]),
+            (tracked_info["module"], tracked_info["class"]),
             self.__dict__,
         )
 
@@ -967,17 +966,19 @@ def _add_tracking_to_class(cls: type[Any], _validate: bool = True) -> type[Any]:
     return new_cls
 
 
-def _reconstruct_tracked_instance(module: str, class_name: str, init_args: dict) -> Any:
-    """Reconstruct a tracked instance for unpickling.
+def _reconstruct_tracked_instance(module: str, class_name: str) -> Any:
+    """Reconstruct an empty tracked instance for unpickling.
 
     Imports the original class from its module, wraps it with track(),
-    and calls it with the stored init_args.
+    and creates an empty instance via __new__ (skipping __init__).
+    State is restored separately by pickle calling __setstate__.
     """
     import importlib
 
     mod = importlib.import_module(module)
     cls = getattr(mod, class_name)
-    return track(cls)(**init_args)
+    tracked_cls = track(cls)
+    return tracked_cls.__new__(tracked_cls)
 
 
 def _create_tracked_instance(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,3 +176,15 @@ def _rebuild_untracked_with_reduce(value: int, extra: str) -> "UntrackedWithRedu
     obj.value = value
     obj.extra = extra
     return obj
+
+
+_init_call_count = 0
+
+
+class UntrackedWithInitCounter:
+    """Tracks how many times __init__ is called, for verifying pickle doesn't re-run it."""
+
+    def __init__(self, value: int):
+        global _init_call_count
+        _init_call_count += 1
+        self.value = value

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -2832,6 +2832,24 @@ class TestPickleSupport:
         # Extra state set after init should be preserved
         assert restored.extra == "modified_after_init"
 
+    def test_pickle_does_not_rerun_init(self):
+        """Unpickling should restore state via __dict__, not re-run __init__."""
+        import pickle
+
+        import tests.conftest as conftest
+        from tests.conftest import UntrackedWithInitCounter
+
+        conftest._init_call_count = 0
+        instance = track(UntrackedWithInitCounter)(value=42)
+        assert conftest._init_call_count == 1
+
+        pickled = pickle.dumps(instance)
+        restored = pickle.loads(pickled)
+
+        assert conftest._init_call_count == 1  # __init__ should NOT run again
+        assert restored.value == 42
+        assert hasattr(restored, "_tracked_info")
+
     def test_pickle_preserves_was_instantiated_flag(self):
         """Lazy created via lens() should preserve _was_instantiated after unpickling."""
         import pickle


### PR DESCRIPTION
Use __new__ to create an empty tracked subclass and let pickle restore __dict__ via __setstate__, matching standard pickle behavior.

This is a better fix of #1 