### PR TITLE
Fix publish workflow version check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Verify tag matches pyproject.toml version
         run: |
           TAG="${GITHUB_REF#refs/tags/v}"
-          VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          VERSION=$(grep -Po '(?<=^version = ")[^"]+' pyproject.toml)
           if [ "$TAG" != "$VERSION" ]; then
             echo "::error::Tag v$TAG does not match pyproject.toml version $VERSION"
             exit 1


### PR DESCRIPTION
Replace tomllib (Python 3.11+) with grep for version extraction. Fixes CI failure when uv defaults to Python 3.10.