### PR TITLE
Fix prettify/transpile output for callables, tuples, and nested indentation

### DIFF
--- a/src/confingy/fingy.py
+++ b/src/confingy/fingy.py
@@ -180,6 +180,34 @@ def prettify_serialized_fingy(data: Any) -> Any:
 
     # Handle dictionaries
     if isinstance(data, dict):
+        # Handle tuples (no _confingy_class key)
+        if data.get(SerializationKeys.TUPLE) is True:
+            return [
+                prettify_serialized_fingy(item)
+                for item in data.get(SerializationKeys.ITEMS, [])
+            ]
+
+        # Handle sets (no _confingy_class key)
+        if data.get(SerializationKeys.SET) is True:
+            return [
+                prettify_serialized_fingy(item)
+                for item in data.get(SerializationKeys.ITEMS, [])
+            ]
+
+        # Handle callables (no _confingy_class key)
+        if SerializationKeys.CALLABLE in data:
+            if data[SerializationKeys.CALLABLE] == "function":
+                module = data.get(SerializationKeys.MODULE, "")
+                name = data.get(SerializationKeys.NAME, "unknown")
+                return f"{module}.{name}"
+            elif data[SerializationKeys.CALLABLE] == "method":
+                obj = prettify_serialized_fingy(data.get(SerializationKeys.OBJECT, {}))
+                method = data.get(SerializationKeys.METHOD, "unknown")
+                if isinstance(obj, dict) and len(obj) == 1:
+                    obj_key = next(iter(obj.keys()))
+                    return f"{obj_key}.{method}"
+                return f"{obj}.{method}"
+
         # Check if this dictionary represents a confingy object
         if SerializationKeys.CLASS in data and SerializationKeys.MODULE in data:
             # This is a confingy object - collapse it
@@ -385,7 +413,7 @@ class _ConfingyTranspiler:
             if value.get(SerializationKeys.SET) is True:
                 return self._transpile_set(value.get(SerializationKeys.ITEMS, []))
             # Check if it's a confingy object
-            if SerializationKeys.CLASS in value:
+            if SerializationKeys.CLASS in value or SerializationKeys.CALLABLE in value:
                 return self._transpile_confingy_object(value)
             else:
                 return self._transpile_dict(value)
@@ -559,65 +587,61 @@ class _ConfingyTranspiler:
         if not fields_dict:
             return f"{class_name}()"
 
-        # Process fields
+        # Increment BEFORE transpiling nested values so they know their depth
+        self.indent_level += 1
         field_args = []
         for field_name, field_value in fields_dict.items():
             value_repr = self._transpile_value(field_value)
+            field_args.append(f"{field_name}={value_repr}")
 
-            # Format field assignment
-            if "\n" in value_repr or len(value_repr) > 50:
-                # Multi-line value
-                self.indent_level += 1
-                indent = self.indent_str * self.indent_level
-                field_args.append(f"{field_name}={value_repr}")
-                self.indent_level -= 1
-            else:
-                field_args.append(f"{field_name}={value_repr}")
+        indent = self.indent_str * self.indent_level
 
-        # Format constructor call
-        if len(field_args) == 1 and len(field_args[0]) < 60:
-            # Single short argument
-            return f"{class_name}({field_args[0]})"
-        else:
-            # Multi-line format
-            self.indent_level += 1
-            indent = self.indent_str * self.indent_level
-            formatted_args = [f"{indent}{arg}" for arg in field_args]
+        # Single short argument - compact form
+        if (
+            len(field_args) == 1
+            and "\n" not in field_args[0]
+            and len(field_args[0]) < 60
+        ):
             self.indent_level -= 1
-            return (
-                f"{class_name}(\n"
-                + ",\n".join(formatted_args)
-                + "\n"
-                + self.indent_str * self.indent_level
-                + ")"
-            )
+            return f"{class_name}({field_args[0]})"
+
+        formatted_args = [f"{indent}{arg}" for arg in field_args]
+        self.indent_level -= 1
+        return (
+            f"{class_name}(\n"
+            + ",\n".join(formatted_args)
+            + "\n"
+            + self.indent_str * self.indent_level
+            + ")"
+        )
 
     def _transpile_lazy(self, class_name: str, config: dict[str, Any]) -> str:
         """Transpile a lazy object."""
         if not config:
             return f"lazy({class_name})()"
 
-        # Process config arguments
+        # Increment BEFORE transpiling nested values so they know their depth
+        self.indent_level += 1
         arg_parts = []
         for key, value in config.items():
             value_repr = self._transpile_value(value)
             arg_parts.append(f"{key}={value_repr}")
 
-        # Format lazy call
+        indent = self.indent_str * self.indent_level
+
+        # Single short argument - compact form
         if len(arg_parts) == 1 and len(arg_parts[0]) < 50:
-            return f"lazy({class_name})({arg_parts[0]})"
-        else:
-            # Multi-line format
-            self.indent_level += 1
-            indent = self.indent_str * self.indent_level
-            formatted_args = [f"{indent}{arg}" for arg in arg_parts]
             self.indent_level -= 1
-            args_str = ",\n".join(formatted_args)
-            return (
-                f"lazy({class_name})(\n{args_str}\n"
-                + self.indent_str * self.indent_level
-                + ")"
-            )
+            return f"lazy({class_name})({arg_parts[0]})"
+
+        formatted_args = [f"{indent}{arg}" for arg in arg_parts]
+        self.indent_level -= 1
+        args_str = ",\n".join(formatted_args)
+        return (
+            f"lazy({class_name})(\n{args_str}\n"
+            + self.indent_str * self.indent_level
+            + ")"
+        )
 
     def _transpile_tracked_class(
         self, class_name: str, init_args: dict[str, Any]
@@ -626,28 +650,29 @@ class _ConfingyTranspiler:
         if not init_args:
             return f"{class_name}()"
 
-        # Process init arguments
+        # Increment BEFORE transpiling nested values so they know their depth
+        self.indent_level += 1
         arg_parts = []
         for key, value in init_args.items():
             value_repr = self._transpile_value(value)
             arg_parts.append(f"{key}={value_repr}")
 
-        # Format constructor call
-        if len(arg_parts) == 1 and len(arg_parts[0]) < 60:
-            return f"{class_name}({arg_parts[0]})"
-        else:
-            # Multi-line format
-            self.indent_level += 1
-            indent = self.indent_str * self.indent_level
-            formatted_args = [f"{indent}{arg}" for arg in arg_parts]
+        indent = self.indent_str * self.indent_level
+
+        # Single short argument - compact form
+        if len(arg_parts) == 1 and "\n" not in arg_parts[0] and len(arg_parts[0]) < 60:
             self.indent_level -= 1
-            return (
-                f"{class_name}(\n"
-                + ",\n".join(formatted_args)
-                + "\n"
-                + self.indent_str * self.indent_level
-                + ")"
-            )
+            return f"{class_name}({arg_parts[0]})"
+
+        formatted_args = [f"{indent}{arg}" for arg in arg_parts]
+        self.indent_level -= 1
+        return (
+            f"{class_name}(\n"
+            + ",\n".join(formatted_args)
+            + "\n"
+            + self.indent_str * self.indent_level
+            + ")"
+        )
 
 
 def transpile_fingy(fingy_data: dict[str, Any] | str | Path) -> str:

--- a/tests/test_fingy.py
+++ b/tests/test_fingy.py
@@ -16,7 +16,7 @@ from confingy import (
     save_fingy,
     serialize_fingy,
 )
-from confingy.fingy import transpile_fingy
+from confingy.fingy import prettify_serialized_fingy, transpile_fingy
 from tests.conftest import (
     Adder,
     CollectionFingy,
@@ -28,6 +28,7 @@ from tests.conftest import (
     NestedFingy,
     ProcessorPipeline,
     TrainingFingy,
+    standalone_function,
 )
 
 
@@ -669,3 +670,90 @@ def test_transpilation_tuples_and_sets():
         compile(python_code, "<string>", "exec")
     except SyntaxError:
         pytest.fail(f"Multi-line single-element tuple has syntax error:\n{python_code}")
+
+
+def test_prettify_collapses_tuples():
+    """Test that prettify collapses tuple metadata into a plain list."""
+    from confingy import prettify_fingy
+
+    fingy = CollectionFingy(
+        numbers_list=[1, 2],
+        numbers_tuple=(10, 20, 30),
+        mapping={"a": 1.0},
+        nested=[],
+    )
+    pretty = prettify_fingy(fingy)
+
+    # Navigate into the prettified structure
+    inner = next(iter(pretty.values()))
+    # Tuple should become a plain list, not a dict with _confingy_tuple
+    assert inner["numbers_tuple"] == [10, 20, 30]
+    assert not isinstance(inner["numbers_tuple"], dict)
+
+
+def test_prettify_collapses_callables():
+    """Test that prettify collapses callable metadata into a dotted string."""
+    serialized = serialize_fingy({"fn": standalone_function})
+    pretty = prettify_serialized_fingy(serialized)
+
+    # Should be "module.func_name", not a raw dict with _confingy_callable
+    assert isinstance(pretty["fn"], str)
+    assert "standalone_function" in pretty["fn"]
+    assert "_confingy_callable" not in str(pretty)
+
+
+def test_transpile_callable_fields():
+    """Test that transpile emits function references for callable fields."""
+    serialized = serialize_fingy({"fn": standalone_function})
+    code = transpile_fingy(serialized)
+
+    # Should reference the function name, not emit a dict literal
+    assert "standalone_function" in code
+    assert "_confingy_callable" not in code
+
+
+def test_transpile_nested_indentation():
+    """Test that deeply nested lazy/tracked configs have correct indentation."""
+    # Use a structure complex enough to force multi-line at multiple depths
+    fingy = TrainingFingy(
+        model=lazy(MyModel, in_features=8, out_features=16),
+        dataloader=lazy(
+            MyDataloader,
+            dataset=MyDataset(
+                num_samples=100,
+                num_features=8,
+                processor=ProcessorPipeline([Adder(1.0), Multiplier(2.0)]),
+            ),
+            batch_size=32,
+        ),
+    )
+
+    serialized = serialize_fingy(fingy)
+    code = transpile_fingy(serialized)
+    lines = code.split("\n")
+
+    # Verify increasing indentation for nested constructs
+    indented_lines = [line for line in lines if line.startswith("    ")]
+    double_indented = [line for line in lines if line.startswith("        ")]
+
+    assert len(indented_lines) > 0, f"Expected indented lines:\n{code}"
+    assert len(double_indented) > 0, f"Expected double-indented lines:\n{code}"
+
+    # Closing parens should align with their opening construct, not be over-indented
+    # Find lines that are just a closing paren (with optional whitespace)
+    close_lines = [(i, line) for i, line in enumerate(lines) if line.strip() == ")"]
+    for i, close_line in close_lines:
+        close_indent = len(close_line) - len(close_line.lstrip())
+        # The line before the closing paren should be more indented
+        prev_nonblank = lines[i - 1]
+        prev_indent = len(prev_nonblank) - len(prev_nonblank.lstrip())
+        assert prev_indent > close_indent, (
+            f"Line {i}: closing paren indent ({close_indent}) should be less "
+            f"than previous line indent ({prev_indent}):\n{code}"
+        )
+
+    # The code should compile
+    try:
+        compile(code, "<string>", "exec")
+    except SyntaxError:
+        pytest.fail(f"Transpiled code has syntax errors:\n{code}")


### PR DESCRIPTION
## Summary
- `prettify_serialized_fingy` now collapses callable and tuple/set dicts instead of leaking `_confingy_*` metadata into output
- `transpile_fingy` now emits function references for callable fields instead of raw dict literals
- Fix indentation in transpiled output: nested lazy/tracked/dataclass constructors now increment indent level *before* transpiling children so inner constructs format at the correct depth

## Root Cause
- Callable dicts from `CallableHandler.serialize()` use `_confingy_callable` + `_confingy_module` + `_confingy_name` but no `_confingy_class` — so `prettify_serialized_fingy` (gated on `_confingy_class`) falls through to the "regular dict" branch, leaking raw metadata
- Same issue for tuple/set dicts (`_confingy_tuple`/`_confingy_set` + `_confingy_items`, no `_confingy_class`)
- `_transpile_value` also gates on `_confingy_class`, so callables fall to `_transpile_dict`
- `_transpile_dataclass`, `_transpile_lazy`, `_transpile_tracked_class` all called `_transpile_value()` at the current indent level, then incremented after — nested multi-line output was formatted at the wrong depth

## Test plan
- [x] `test_prettify_collapses_tuples` — tuple fields produce plain lists, not metadata dicts
- [x] `test_prettify_collapses_callables` — callable fields produce `module.name` strings
- [x] `test_transpile_callable_fields` — function references in transpiled output, not dict literals
- [x] `test_transpile_nested_indentation` — nested constructs have increasing indentation with properly aligned closing parens
- [x] All 268 existing tests pass
- [x] `make format-check && make lint && make mypy` clean