### PR TITLE
Add pathlib.Path serialization support

### DIFF
--- a/src/confingy/fingy.py
+++ b/src/confingy/fingy.py
@@ -180,6 +180,12 @@ def prettify_serialized_fingy(data: Any) -> Any:
 
     # Handle dictionaries
     if isinstance(data, dict):
+        # Handle pathlib.Path objects
+        if data.get(SerializationKeys.MODULE) == "pathlib" and str(
+            data.get(SerializationKeys.CLASS, "")
+        ).endswith("Path"):
+            return data.get(SerializationKeys.NAME, "")
+
         # Check if this dictionary represents a confingy object
         if SerializationKeys.CLASS in data and SerializationKeys.MODULE in data:
             # This is a confingy object - collapse it
@@ -543,6 +549,12 @@ class _ConfingyTranspiler:
             type_name = obj.get(SerializationKeys.NAME, "Unknown")
             self.imports.add((module_name, type_name))
             return type_name
+
+        elif module_name == "pathlib":
+            # pathlib.Path object
+            path_str = obj.get(SerializationKeys.NAME, "")
+            self.imports.add(("pathlib", "Path"))
+            return f"Path({path_str!r})"
 
         elif SerializationKeys.UNSERIALIZABLE in obj:
             # Unserializable object - add as comment

--- a/src/confingy/serde.py
+++ b/src/confingy/serde.py
@@ -6,6 +6,7 @@ import logging
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 from confingy.exceptions import (
@@ -282,6 +283,38 @@ class EnumHandler(SerializationHandler):
             raise DeserializationError(
                 f"Could not recreate enum {data[SerializationKeys.MODULE]}.{data[SerializationKeys.CLASS]}.{data.get(SerializationKeys.NAME)}: {e}"
             ) from None
+
+
+class PathHandler(SerializationHandler):
+    """Handler for pathlib.Path objects."""
+
+    _PATH_CLASSES = (
+        "Path",
+        "PosixPath",
+        "WindowsPath",
+        "PurePath",
+        "PurePosixPath",
+        "PureWindowsPath",
+    )
+
+    def can_handle(self, obj: Any) -> bool:
+        return isinstance(obj, Path)
+
+    def serialize(self, obj: Any, context: SerializationContext) -> dict[str, Any]:
+        return {
+            SerializationKeys.CLASS: "Path",
+            SerializationKeys.MODULE: "pathlib",
+            SerializationKeys.NAME: str(obj),
+        }
+
+    def deserialize(self, data: Any, context: DeserializationContext) -> Any:
+        if not isinstance(data, dict):
+            return None
+        if data.get(SerializationKeys.CLASS) not in self._PATH_CLASSES:
+            return None
+        if data.get(SerializationKeys.MODULE) != "pathlib":
+            return None
+        return Path(data.get(SerializationKeys.NAME, ""))
 
 
 class LazyHandler(SerializationHandler):
@@ -661,6 +694,7 @@ class HandlerRegistry:
     def get_default_handlers():
         """Get the default set of handlers in the correct order."""
         return [
+            PathHandler(),  # Must be before PrimitiveHandler (Path is not a primitive)
             EnumHandler(),  # Must be before PrimitiveHandler (StrEnum/IntEnum are str/int)
             PrimitiveHandler(),
             LazyHandler(),

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -5,6 +5,7 @@ Tests for confingy.serde module - serialization handlers and context.
 import enum
 from dataclasses import dataclass
 from enum import IntEnum
+from pathlib import Path
 from typing import Optional
 
 import pytest
@@ -65,6 +66,13 @@ class Priority(IntEnum):
 class Status(str, enum.Enum):
     ACTIVE = "active"
     INACTIVE = "inactive"
+
+
+@track
+class WithPathTracked:
+    def __init__(self, data_dir: Path, name: str):
+        self.data_dir = data_dir
+        self.name = name
 
 
 def test_primitive_types():
@@ -1238,3 +1246,62 @@ def test_enum_transpile():
     code = transpile_fingy(serialized)
     assert "Color.GREEN" in code
     assert "from tests.test_serde import Color" in code
+
+
+# ============================================================================
+# Tests for pathlib.Path serialization/deserialization
+# ============================================================================
+
+
+def test_path_serialization_roundtrip():
+    """Test that pathlib.Path objects survive serialization and deserialization."""
+    from pathlib import Path
+
+    data = {"train_dir": Path("/data/train"), "output": Path("results/run1")}
+
+    serialized = serialize_fingy(data)
+    deserialized = deserialize_fingy(serialized)
+
+    assert isinstance(deserialized["train_dir"], Path)
+    assert isinstance(deserialized["output"], Path)
+    assert deserialized["train_dir"] == Path("/data/train")
+    assert deserialized["output"] == Path("results/run1")
+
+
+def test_path_in_tracked_class():
+    """Test Path as a field in a @track class."""
+    from pathlib import Path
+
+    instance = WithPathTracked(data_dir=Path("/mnt/data"), name="experiment")
+    serialized = serialize_fingy(instance)
+    deserialized = deserialize_fingy(serialized)
+
+    assert isinstance(deserialized.data_dir, Path)
+    assert deserialized.data_dir == Path("/mnt/data")
+    assert deserialized.name == "experiment"
+
+
+def test_path_prettify():
+    """Test that prettify collapses Path objects into a clean string."""
+    from pathlib import Path
+
+    from confingy.fingy import prettify_serialized_fingy
+
+    serialized = serialize_fingy({"path": Path("/data/train")})
+    pretty = prettify_serialized_fingy(serialized)
+
+    assert pretty["path"] == "/data/train"
+    assert "_confingy_class" not in str(pretty)
+
+
+def test_path_transpile():
+    """Test that transpile emits Path('...') for pathlib.Path fields."""
+    from pathlib import Path
+
+    from confingy.fingy import transpile_fingy
+
+    serialized = serialize_fingy({"path": Path("/data/train")})
+    code = transpile_fingy(serialized)
+
+    assert 'Path("/data/train")' in code or "Path('/data/train')" in code
+    assert "from pathlib import Path" in code


### PR DESCRIPTION
## Summary
- Add `PathHandler` to serialize/deserialize `pathlib.Path` objects
- Serializes as `{"_confingy_class": "Path", "_confingy_module": "pathlib", "_confingy_name": "/data/train"}`
- Uses `"Path"` (not `PosixPath`/`WindowsPath`) for cross-platform portability
- Deserializes all pathlib Path variants (`PosixPath`, `WindowsPath`, `PurePath`, etc.)
- `prettify_serialized_fingy` collapses Path objects to clean path strings
- `transpile_fingy` emits `Path("/data/train")` with proper import

## Motivation
`pathlib.Path` is the standard Python type for file paths and appears in a lot of my smaller ML project configs. Without handler support, `serialize_fingy()` raises `SerializationError` for any class with a Path field.
Adding support for pathlib helps me use this more :) 

## Test plan
- [x] `test_path_serialization_roundtrip` — Path survives serialize/deserialize, type preserved
- [x] `test_path_in_tracked_class` — Path as a `@track` constructor argument
- [x] `test_path_prettify` — clean string output, no metadata leakage
- [x] `test_path_transpile` — `Path("...")` in transpiled output with import
- [x] All 268 existing tests pass
- [x] `make format-check && make lint && make mypy` clean