### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,3 +388,16 @@ config = MyConfig(my_obj=Foo(1, "baz"))
 **Exceptions:** `ValidationError`, `SerializationError`, `DeserializationError`
 
 **CLI:** `confingy serialize`, `confingy transpile`, `confingy viz`
+
+## Development
+
+### Releasing a new version
+
+1. Create a branch and bump the `version` in `pyproject.toml`
+2. Run `uv sync --group dev --extra viz` to update the lockfile
+3. Open a PR, get it reviewed, and merge to `main`
+4. Create a GitHub release with a tag matching the version (e.g. `v0.1.1`):
+   ```bash
+   gh release create v0.1.1 --title "v0.1.1" --generate-notes
+   ```
+   The [publish workflow](.github/workflows/publish.yml) will run tests, linting, and type checking, then build and publish to PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "confingy"
-version = "0.1.0"
+version = "0.1.1"
 description = "An implicit configuration system"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "confingy"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Bumps version in `pyproject.toml` from 0.1.0 to 0.1.1 in preparation for release.

## Release steps
After merging, create a GitHub release with tag `v0.1.1` to trigger the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)