### PR TITLE
Fix default_factory not being called on direct @track instantiation

### DIFF
--- a/src/confingy/tracking.py
+++ b/src/confingy/tracking.py
@@ -911,8 +911,12 @@ def _add_tracking_to_class(cls: type[Any], _validate: bool = True) -> type[Any]:
                 "class_hash": hash_class(self.__class__),
             }
 
-        # Call original __init__
-        original_init(self, *args, **kwargs)
+        # Call original __init__, injecting resolved Field defaults so that
+        # default_factory values are passed through (matching lazy+instantiate behavior).
+        if should_track:
+            original_init(self, **init_kwargs)
+        else:
+            original_init(self, *args, **kwargs)
 
     # Add the lazy classmethod
     def lazy_classmethod(cls_arg: type[T], *args: Any, **kwargs: Any) -> Lazy[T]:

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -2696,6 +2696,43 @@ class TestFieldDefaultFactory:
         assert lazy1.items == [1, 2, 3, 4]
         assert lazy2.items == [1, 2, 3]  # Unchanged
 
+    def test_field_default_factory_direct_instantiation(self):
+        """default_factory should work with direct @track instantiation too."""
+        from dataclasses import field
+
+        call_count = [0]
+
+        def make_list():
+            call_count[0] += 1
+            return [1, 2, 3]
+
+        @track
+        class WithFactory:
+            def __init__(self, items: list = field(default_factory=make_list)):
+                self.items = items
+
+        obj = WithFactory()
+        assert obj.items == [1, 2, 3]
+        assert call_count[0] >= 1
+
+        # Each instantiation should get a fresh list
+        obj2 = WithFactory()
+        obj.items.append(4)
+        assert obj2.items == [1, 2, 3]
+
+    def test_field_default_factory_parity(self):
+        """Direct instantiation and lazy+instantiate should produce same result."""
+        from dataclasses import field
+
+        @track
+        class WithFactory:
+            def __init__(self, items: list = field(default_factory=list)):
+                self.items = items
+
+        direct = WithFactory()
+        via_lazy = WithFactory.lazy().instantiate()
+        assert direct.items == via_lazy.items == []
+
     def test_field_default_value_is_used(self):
         """Field.default should be used when no factory is provided."""
         from dataclasses import field


### PR DESCRIPTION
When a @track-decorated class used field(default_factory=...), the factory result was only stored in tracking metadata but never passed to __init__. The lazy()+instantiate() path correctly resolved the factory. Now init_with_tracking passes the resolved kwargs (which include factory results) to original_init, making both paths consistent.