### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "confingy"
-version = "0.1.1"
+version = "0.1.2"
 description = "An implicit configuration system"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "confingy"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Bump version from 0.1.1 to 0.1.2

## Changes since v0.1.1
- Fix default_factory not being called on direct @track instantiation (#12)
- Suppress pydantic warnings when constructor args shadow BaseModel attributes (#11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)