### PR TITLE
feat: add datetime serde support (closes #20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build/
 # Virtual environments
 .venv/
 venv/
+.worktrees/
 
 # IDE
 .idea/

--- a/src/confingy/serde.py
+++ b/src/confingy/serde.py
@@ -1,4 +1,5 @@
 import dataclasses
+import datetime
 import enum
 import importlib
 import inspect
@@ -315,6 +316,80 @@ class PathHandler(SerializationHandler):
         if data.get(SerializationKeys.MODULE) != "pathlib":
             return None
         return Path(data.get(SerializationKeys.NAME, ""))
+
+
+class DatetimeHandler(SerializationHandler):
+    """Handler for ``datetime`` stdlib leaf types.
+
+    Covers ``datetime.date``, ``datetime.datetime``, ``datetime.time``, and
+    ``datetime.timedelta``. Serialized as a leaf using the same
+    ``{_confingy_class, _confingy_module, _confingy_name}`` envelope as
+    :class:`PathHandler`.
+
+    Wire formats::
+
+        date       -> {"_confingy_class": "date",      "_confingy_module": "datetime", "_confingy_name": "2024-01-01"}
+        datetime   -> {"_confingy_class": "datetime",  "_confingy_module": "datetime", "_confingy_name": "2024-01-01T12:34:56+00:00"}
+        time       -> {"_confingy_class": "time",      "_confingy_module": "datetime", "_confingy_name": "12:34:56"}
+        timedelta  -> {"_confingy_class": "timedelta", "_confingy_module": "datetime", "_confingy_name": 93784.0}
+
+    ``date`` / ``datetime`` / ``time`` use ``isoformat()`` / ``fromisoformat()``.
+    Exact round-trip is guaranteed for values that ``isoformat()`` itself emits
+    on the same Python version (the only values we ever feed back in).
+
+    ``timedelta`` uses ``total_seconds()`` (float) for the wire value because the
+    stdlib has no ``timedelta.fromisoformat``. ``total_seconds()`` preserves
+    microsecond resolution exactly for every ``timedelta`` representable by the
+    stdlib; sub-microsecond inputs are already clamped at construction time.
+
+    Dispatch is by exact ``type(obj)`` rather than ``isinstance`` because
+    ``datetime.datetime`` subclasses ``datetime.date`` — a naive isinstance
+    check would mis-serialize datetimes as dates.
+    """
+
+    # Map of exact stdlib type -> (wire class name) used for both directions.
+    _TYPES = {
+        datetime.datetime: "datetime",
+        datetime.date: "date",
+        datetime.time: "time",
+        datetime.timedelta: "timedelta",
+    }
+
+    def can_handle(self, obj: Any) -> bool:
+        return type(obj) in self._TYPES
+
+    def serialize(self, obj: Any, context: SerializationContext) -> dict[str, Any]:
+        cls = type(obj)
+        if cls is datetime.timedelta:
+            name: Any = obj.total_seconds()
+        else:
+            name = obj.isoformat()
+        return {
+            SerializationKeys.CLASS: self._TYPES[cls],
+            SerializationKeys.MODULE: "datetime",
+            SerializationKeys.NAME: name,
+        }
+
+    def deserialize(self, data: Any, context: DeserializationContext) -> Any:
+        if not isinstance(data, dict):
+            return None
+        if data.get(SerializationKeys.MODULE) != "datetime":
+            return None
+        class_name = data.get(SerializationKeys.CLASS)
+        name = data.get(SerializationKeys.NAME)
+        if class_name in ("date", "datetime", "time"):
+            if not isinstance(name, str):
+                return None
+            if class_name == "date":
+                return datetime.date.fromisoformat(name)
+            if class_name == "datetime":
+                return datetime.datetime.fromisoformat(name)
+            return datetime.time.fromisoformat(name)
+        if class_name == "timedelta":
+            if not isinstance(name, (int, float)):
+                return None
+            return datetime.timedelta(seconds=float(name))
+        return None
 
 
 class LazyHandler(SerializationHandler):
@@ -696,6 +771,7 @@ class HandlerRegistry:
         return [
             PathHandler(),  # Must be before PrimitiveHandler (Path is not a primitive)
             EnumHandler(),  # Must be before PrimitiveHandler (StrEnum/IntEnum are str/int)
+            DatetimeHandler(),  # Must be before PrimitiveHandler (datetime types are leaves, not primitives)
             PrimitiveHandler(),
             LazyHandler(),
             TrackedInstanceHandler(),

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -296,6 +296,10 @@ def test_handler_order_matters():
     primitive_index = handler_names.index("PrimitiveHandler")
     assert enum_index < primitive_index
 
+    # DatetimeHandler must come before PrimitiveHandler (datetime values are leaves, not primitives)
+    datetime_index = handler_names.index("DatetimeHandler")
+    assert datetime_index < primitive_index
+
     # Lazy and TrackedInstance should come before generic handlers
     lazy_index = handler_names.index("LazyHandler")
     tracked_index = handler_names.index("TrackedInstanceHandler")
@@ -610,6 +614,7 @@ def test_handler_registry():
         "TrackedInstanceHandler",
         "CollectionHandler",
         "TypeHandler",  # Added TypeHandler
+        "DatetimeHandler",
     ]
 
     for expected in expected_handlers:
@@ -1342,3 +1347,14 @@ def test_datetime_roundtrip(value):
     restored = deserialize_fingy(serialized)
     assert restored == value
     assert type(restored) is type(value)
+
+
+def test_datetime_dispatches_before_date_for_datetime_instance():
+    """A datetime.datetime must serialize as 'datetime', not 'date'.
+
+    datetime.datetime subclasses datetime.date, so a sloppy isinstance check
+    would route it to the date branch.
+    """
+    serialized = serialize_fingy(datetime.datetime(2024, 1, 1, 12, 0, 0))
+    assert serialized["_confingy_class"] == "datetime"
+    assert serialized["_confingy_module"] == "datetime"

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -1035,8 +1035,6 @@ class Downloader:
 
 def _save_tracked_downloader(path: str):
     """Helper function to save a tracked Downloader in a separate process."""
-    import json
-
     from confingy import serialize_fingy, track
 
     downloader = track(Downloader)(
@@ -1330,7 +1328,12 @@ def test_path_transpile():
             2024, 1, 1, 12, 34, 56, tzinfo=datetime.timezone.utc
         ),  # tz-aware UTC
         datetime.datetime(
-            2024, 1, 1, 12, 34, 56,
+            2024,
+            1,
+            1,
+            12,
+            34,
+            56,
             tzinfo=datetime.timezone(datetime.timedelta(hours=-5)),
         ),  # tz-aware non-UTC offset
         datetime.time(12, 34, 56),
@@ -1358,3 +1361,20 @@ def test_datetime_dispatches_before_date_for_datetime_instance():
     serialized = serialize_fingy(datetime.datetime(2024, 1, 1, 12, 0, 0))
     assert serialized["_confingy_class"] == "datetime"
     assert serialized["_confingy_module"] == "datetime"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        datetime.date(2024, 1, 1),
+        datetime.datetime(2024, 1, 1, 12, 34, 56, tzinfo=datetime.timezone.utc),
+        datetime.time(12, 34, 56),
+        datetime.timedelta(days=1, seconds=93784),
+    ],
+)
+def test_datetime_serialization_is_json_safe(value):
+    """Serialized datetime values must survive json.dumps/json.loads."""
+    serialized = serialize_fingy(value)
+    restored = deserialize_fingy(json.loads(json.dumps(serialized)))
+    assert restored == value
+    assert type(restored) is type(value)

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -2,7 +2,9 @@
 Tests for confingy.serde module - serialization handlers and context.
 """
 
+import datetime
 import enum
+import json
 from dataclasses import dataclass
 from enum import IntEnum
 from pathlib import Path
@@ -1305,3 +1307,38 @@ def test_path_transpile():
 
     assert 'Path("/data/train")' in code or "Path('/data/train')" in code
     assert "from pathlib import Path" in code
+
+
+# ============================================================================
+# Tests for datetime stdlib types serialization/deserialization (issue #20)
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        datetime.date(2024, 1, 1),
+        datetime.date(1970, 1, 1),
+        datetime.datetime(2024, 1, 1, 12, 34, 56),  # naive
+        datetime.datetime(2024, 1, 1, 12, 34, 56, 123456),  # naive + microseconds
+        datetime.datetime(
+            2024, 1, 1, 12, 34, 56, tzinfo=datetime.timezone.utc
+        ),  # tz-aware UTC
+        datetime.datetime(
+            2024, 1, 1, 12, 34, 56,
+            tzinfo=datetime.timezone(datetime.timedelta(hours=-5)),
+        ),  # tz-aware non-UTC offset
+        datetime.time(12, 34, 56),
+        datetime.time(0, 0, 0, 1),  # microsecond resolution
+        datetime.timedelta(days=1, hours=2, minutes=3, seconds=4),  # positive
+        datetime.timedelta(0),  # zero
+        datetime.timedelta(seconds=-90),  # negative
+        datetime.timedelta(microseconds=123456),  # sub-second
+    ],
+)
+def test_datetime_roundtrip(value):
+    """Round-trip each datetime stdlib type through serialize_fingy."""
+    serialized = serialize_fingy(value)
+    restored = deserialize_fingy(serialized)
+    assert restored == value
+    assert type(restored) is type(value)


### PR DESCRIPTION
## Summary

Closes #20. Adds round-trip serialization support for the four \`datetime\`
stdlib leaf types: \`date\`, \`datetime\`, \`time\`, \`timedelta\`. No new runtime
dependencies.

## Approach

- New \`DatetimeHandler\` in \`src/confingy/serde.py\`, registered before
  \`PrimitiveHandler\` (same convention as \`PathHandler\` / \`EnumHandler\`).
- Dispatch by \`type(obj)\` rather than \`isinstance\` so that
  \`datetime.datetime\` (a subclass of \`datetime.date\`) routes to the
  \`datetime\` branch instead of \`date\`.
- Wire format reuses the existing \`{_confingy_class, _confingy_module,
  _confingy_name}\` envelope — no new \`SerializationKeys\`.

## Wire format

\`\`\`json
{"_confingy_class": "date",      "_confingy_module": "datetime", "_confingy_name": "2024-01-01"}
{"_confingy_class": "datetime",  "_confingy_module": "datetime", "_confingy_name": "2024-01-01T12:34:56+00:00"}
{"_confingy_class": "time",      "_confingy_module": "datetime", "_confingy_name": "12:34:56"}
{"_confingy_class": "timedelta", "_confingy_module": "datetime", "_confingy_name": 93784.0}
\`\`\`

\`date\` / \`datetime\` / \`time\` use \`isoformat()\` / \`fromisoformat()\` (exact
on Python 3.10+). \`timedelta\` uses \`total_seconds()\` because the stdlib
has no \`timedelta.fromisoformat\`; microsecond resolution is preserved.

## Tests

- Parametrized round-trip for all four types (incl. naive + tz-aware
  datetimes, microsecond \`time\`, positive/zero/negative/sub-second
  \`timedelta\`).
- Handler-ordering assertions (\`DatetimeHandler\` before \`PrimitiveHandler\`;
  \`datetime.datetime\` instances dispatch as \`"datetime\"\`, not \`"date\"\`).
- JSON safety: \`json.dumps(serialize_fingy(x))\` succeeds for all four types.

## Definition of done

- [x] All four \`datetime\` types round-trip.
- [x] No new runtime dependencies.
- [x] \`make pytest\`, \`make mypy\`, \`make lint\`, \`make format-check\` all clean.
- [x] Handler ordering documented inline.