### PR TITLE
perf: cache validation models per class

### DIFF
--- a/src/confingy/tracking.py
+++ b/src/confingy/tracking.py
@@ -1,6 +1,8 @@
 import functools
 import inspect
 import logging
+import weakref
+from collections.abc import MutableMapping
 from contextlib import contextmanager
 from dataclasses import MISSING, Field
 from typing import (
@@ -147,8 +149,8 @@ def _args_to_kwargs(
     return init_kwargs
 
 
-def _create_validation_model(cls: type[Any]) -> type[BaseModel]:
-    """Create a Pydantic validation model for a class's __init__ signature."""
+def _build_validation_model(cls: type[Any]) -> type[BaseModel]:
+    """Build a Pydantic validation model for a class's __init__ signature."""
     import warnings
     from typing import get_type_hints
 
@@ -187,6 +189,37 @@ def _create_validation_model(cls: type[Any]) -> type[BaseModel]:
             __config__=model_config,
             **fields,  # type: ignore
         )
+
+
+# Validation models are a pure function of the class, so they are cached and
+# shared by every Lazy/tracked instance of that class. A WeakKeyDictionary is
+# used (rather than functools.lru_cache) because track() creates a new subclass
+# per call, so a strong-ref cache would keep short-lived dynamic classes alive
+# forever.
+_VALIDATION_MODEL_CACHE: MutableMapping[type[Any], type[BaseModel]] = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def _create_validation_model(cls: type[Any]) -> type[BaseModel]:
+    """Get the Pydantic validation model for a class's __init__ signature.
+
+    The model is built once per class and cached. This assumes a class's
+    `__init__` signature and type hints do not change after the model is first
+    built, which holds for normal (module-level) class definitions.
+
+    Args:
+        cls: The class whose `__init__` arguments should be validated.
+
+    Returns:
+        The validation model for `cls`.
+    """
+    model = _VALIDATION_MODEL_CACHE.get(cls)
+    if model is None:
+        # Errors (e.g. unresolvable forward refs) propagate and are not cached.
+        model = _build_validation_model(cls)
+        _VALIDATION_MODEL_CACHE[cls] = model
+    return model
 
 
 class Lazy(Generic[T]):

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -2793,8 +2793,8 @@ class TestPickleSupport:
 
         assert restored.middle.inner.value == 10
 
-    def test_validation_model_rebuilt_after_unpickle(self):
-        """The validation model should be rebuilt after unpickling."""
+    def test_validation_model_restored_after_unpickle(self):
+        """The validation model should be restored after unpickling."""
         import pickle
 
         from tests.conftest import Inner
@@ -2806,13 +2806,13 @@ class TestPickleSupport:
         pickled = pickle.dumps(lazy_original)
         lazy_restored = pickle.loads(pickled)
 
-        # Validation model should be rebuilt after unpickling
-        assert lazy_restored._confingy_validation_model is not None
-        new_model = lazy_restored._confingy_validation_model
+        # Validation model should be restored after unpickling. Models are cached
+        # per class, so the restored Lazy shares the original's model.
+        assert lazy_restored._confingy_validation_model is old_model
 
-        # Not the same object (rebuilt), but equivalent structure
-        assert new_model is not old_model
-        assert set(old_model.model_fields.keys()) == set(new_model.model_fields.keys())
+        # And the restored model still validates
+        with pytest.raises(ValidationError):
+            lazy_restored.value = "not an int"
 
         # And it should still work for validation
         lazy_restored.value = 42  # Should not raise
@@ -3045,3 +3045,123 @@ class TestPydanticFieldShadowing:
 
         with pytest.raises(ValidationError):
             WithSchema(schema=123)
+
+
+class TestValidationModelCache:
+    """Tests for the per-class validation model cache."""
+
+    def test_lazies_of_same_class_share_a_model(self):
+        """Two Lazy instances of the same class share one validation model."""
+
+        @track
+        class Shared:
+            def __init__(self, value: int):
+                self.value = value
+
+        first = Shared.lazy(value=1)
+        second = Shared.lazy(value=2)
+
+        assert first._confingy_validation_model is not None
+        assert first._confingy_validation_model is second._confingy_validation_model
+
+    def test_different_classes_get_different_models(self):
+        """Distinct classes must not share a validation model."""
+
+        @track
+        class First:
+            def __init__(self, value: int):
+                self.value = value
+
+        @track
+        class Second:
+            def __init__(self, value: int):
+                self.value = value
+
+        assert (
+            First.lazy(value=1)._confingy_validation_model
+            is not Second.lazy(value=2)._confingy_validation_model
+        )
+
+    def test_cached_model_still_validates(self):
+        """A cached model still rejects invalid args on later instances."""
+
+        @track
+        class Validated:
+            def __init__(self, value: int):
+                self.value = value
+
+        Validated.lazy(value=1)  # Populate the cache
+
+        with pytest.raises(ValidationError):
+            Validated.lazy(value="not an int")
+
+        with pytest.raises(ValidationError):
+            Validated(value="not an int")
+
+    def test_subclass_gets_its_own_model(self):
+        """A subclass with a narrower __init__ does not reuse the parent's model."""
+
+        @track
+        class Parent:
+            def __init__(self, value: int, extra: str = "x"):
+                self.value = value
+                self.extra = extra
+
+        @track
+        class Child(Parent):
+            def __init__(self, value: int):
+                super().__init__(value)
+
+        parent_model = Parent.lazy(value=1)._confingy_validation_model
+        child_model = Child.lazy(value=1)._confingy_validation_model
+
+        assert parent_model is not child_model
+        assert set(parent_model.model_fields) == {"value", "extra"}
+        assert set(child_model.model_fields) == {"value"}
+
+    def test_model_built_once_per_class(self, monkeypatch):
+        """Building many lazies of one class only builds the model once."""
+        from confingy import tracking
+
+        @track
+        class Counted:
+            def __init__(self, value: int):
+                self.value = value
+
+        calls = 0
+        original = tracking._build_validation_model
+
+        def counting_build(cls):
+            nonlocal calls
+            calls += 1
+            return original(cls)
+
+        monkeypatch.setattr(tracking, "_build_validation_model", counting_build)
+
+        for i in range(100):
+            Counted.lazy(value=i)
+
+        # One build for Counted, then 99 cache hits
+        assert calls == 1
+
+    def test_dynamic_classes_are_not_kept_alive(self):
+        """The cache must not keep short-lived tracked classes alive."""
+        import gc
+        import weakref
+
+        from confingy import tracking
+
+        class Plain:
+            def __init__(self, value: int):
+                self.value = value
+
+        tracked = track(Plain)
+        lazy_obj = tracked.lazy(value=1)
+        assert lazy_obj._confingy_validation_model is not None
+        assert tracked in tracking._VALIDATION_MODEL_CACHE
+
+        ref = weakref.ref(tracked)
+        del tracked, lazy_obj
+        gc.collect()
+
+        assert ref() is None


### PR DESCRIPTION
## Problem

`_create_validation_model` builds a pydantic model from a class's `__init__` signature, and it was called on **every** `Lazy` construction, every tracked instantiation, and every unpickle. Configs that build many lazies over a modest number of distinct classes pay for the same `create_model` call thousands of times.

## Change

The builder is renamed to `_build_validation_model` (body unchanged). `_create_validation_model` is now a thin cached front over it.

This is safe because the model is a pure function of `cls`: it reads `inspect.signature(cls.__init__)` and `get_type_hints(cls.__init__)`, and nothing mutates the result — `Lazy` only ever *instantiates* it to validate (`_validate_config`, `__setattr__`). The one assumption added is that a class's `__init__` signature does not change after the model is first built, which holds for normal class definitions and is documented in the docstring.

### Why `WeakKeyDictionary` and not `lru_cache`

`lru_cache(maxsize=None)` holds strong refs forever, and dynamically created classes do reach this cache:

- `SomeClass.lazy(...)` → `lazy_classmethod` passes the **tracked subclass** built by `_add_tracking_to_class`, not the original. (`_original_cls` unwrapping in `Lazy.__init__` only applies to lazy factory functions.)
- `track()` mints a fresh subclass on every call, including `_reconstruct_tracked_instance` on every unpickle.

For `@track`-decorated module-level classes that's harmless — one subclass, alive for the process anyway. But runtime `track(Plain)` calls would accumulate pinned classes under a strong-ref cache. Weak keys let them be collected; there's a test asserting this.

Consequence: up to two cached models per class — one keyed on the original class (from `@track` decoration) and one on the tracked subclass (from the first `.lazy()`). Both are equivalent. I deliberately didn't seed one from the other, to avoid coupling the cache to subclass-construction details.

### Unchanged behavior

- Errors are not cached — classes whose `get_type_hints` raises behave exactly as today.
- `disable_validation()` / `skip_validation` paths never call the function.

## Numbers

Building 5,000 lazies of a single 4-arg class: **1.67s → 0.45s** (3.7x). The win scales with the instances-per-class ratio, since build count goes from once-per-instance to once-per-class.

## Tests

`302 passed`; mypy and ruff clean.

New `TestValidationModelCache` covers: model sharing across lazies of one class, distinct classes getting distinct models, validation still firing through a cached model (both `.lazy()` and direct construction), subclasses with narrower `__init__` getting their own model, one build per class across 100 lazies, and weakref collection of abandoned tracked classes.

One existing test changed: `test_validation_model_rebuilt_after_unpickle` asserted `new_model is not old_model`, which the cache makes false by design. It's renamed to `test_validation_model_restored_after_unpickle` and now asserts the restored `Lazy` shares the cached model *and* still raises `ValidationError` on an invalid `__setattr__` — a stronger check of what that test was actually protecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)