### PR TITLE
ci: fix docs workflow blocked by allowed-actions policy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,10 +28,26 @@ jobs:
       - name: Build docs
         run: make docs
 
+      # NOTE: actions/upload-pages-artifact is not usable here — it internally
+      # references actions/upload-artifact@v4, and indirect references are not
+      # covered by the org's "GitHub-owned actions" allowance. Inline what that
+      # action does instead: tar the site and upload it as `github-pages`.
+      - name: Archive docs site
+        run: |
+          tar \
+            --dereference --hard-dereference \
+            --directory _build/docs \
+            -cvf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git --exclude=.github \
+            .
+
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          path: _build/docs
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          if-no-files-found: error
 
   deploy:
     needs: build


### PR DESCRIPTION
## Problem

The `docs` workflow fails on push to `main`:

> Error: The action `actions/upload-artifact@v4` is not allowed in `runwayml/confingy` because all actions must be from a repository owned by your enterprise, created by GitHub, verified in the GitHub Marketplace, or match one of the patterns: ...

The org policy has `github_owned_allowed: true`, but that exemption only applies to actions referenced **directly** from a workflow. `actions/upload-pages-artifact` is a composite action that internally references `actions/upload-artifact@v4`, and that nested reference is checked against the pattern allowlist only — where it isn't listed.

## Fix

Inline what `upload-pages-artifact` does: tar the built site into `$RUNNER_TEMP/artifact.tar` and upload it under the `github-pages` artifact name using a directly-referenced, SHA-pinned `actions/upload-artifact` (v4.6.2). `actions/deploy-pages` in the `deploy` job is a plain JS action with no nested action references, so it's unaffected.

## Verification

This is a server-side policy check, so it can only be verified by running the workflow. `docs` triggers on push to `main` only, so it won't run on this PR — the real check is the run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)