### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "confingy"
-version = "0.1.2"
+version = "0.2.0"
 description = "An implicit configuration system"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "confingy"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Bumps the version to 0.2.0 ahead of the release. Minor bump since datetime serde support (#21) is a new feature.

Changes since v0.1.2:
- feat: add datetime serde support (#21)
- perf: cache validation models per class (#33)
- chore: pin GitHub Actions to full commit SHAs (#16)
- ci: inline pages artifact upload to satisfy allowed-actions policy (#34)

🤖 Generated with [Claude Code](https://claude.com/claude-code)