### PR TITLE
ci: bump pypi-publish action to v1.14.2 for metadata 2.5 support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Build package
         run: uv build
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
The v0.2.0 publish job failed before uploading anything to PyPI:

\`\`\`
Checking dist/confingy-0.2.0-py3-none-any.whl: ERROR InvalidDistribution:
  Invalid distribution metadata: '2.5' is not a valid metadata version
\`\`\`

\`uv build\` now emits \`Metadata-Version: 2.5\`, and the twine bundled in \`pypa/gh-action-pypi-publish\` v1.14.0 predates support for it. v1.14.2 ships twine v7, which [explicitly adds metadata 2.5 upload support](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.2).

Pinned to the full commit SHA per the repo's allowed-actions policy.

Once merged, v0.2.0 needs to be re-tagged so the release event picks up the fixed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)